### PR TITLE
Update plugin.py

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -21,25 +21,28 @@
         <h3>Configuration</h3>
         Configure correctly. The plugin works using the default settings, but your system might need different settings...
         <ul style="list-style-type:square">
-            <li>GPIO Pin Number - The GPIO Pin (BCM!) to which your NPN sensor is connected. To avoid conflicts, make sure the gpio pin is not managed/configured somewhere else on your system to prevent confllicts. You can still use the normal GPIO drivers in domoticz for other pins as long as you don't configure the same pins</li>
+            <li>GPIO Pin Number - The GPIO Pin (BCM!) to which your NPN sensor is connected. To avoid conflicts, make sure the GPIO pin is not managed/configured somewhere else on your system to prevent confllicts. You can still use the normal GPIO drivers in domoticz for other pins as long as you don't configure the same pins.</li>
             <li>Resistor Type - Configure the correct type of resistor. If the NPN is soldered to the GPIO without any physical resistors in a scheme, you definitely should configure a resistor here. </li>
-            <li>Interrupt Mode - Configure if you want the meter to be triggered if the pin goes from 1 to 0 (falling), from 0 to -1 (rising) or on both changes (both). Normally it should be either falling or rising, but not both (both will get you double readings) </li>
-            <li>Debounce Time - Configure the cooldown time after the interrupt to prevent interrupt flooding. A high number is recommended, but it should be less then the time it takes to have 1 liter going throught your watermeter, to prevent lost measurements </li> 
+            <li>Interrupt and Check mode:</li>
+            <li>-Interrupt: Configure if you want the meter to be triggered if the pin goes from 1 to 0 (falling), from 0 to -1 (rising) or on both changes (both). Normally it should be either falling or rising, but not both (both will get you double readings).</li>
+            <li>-Last value check: Configure the false-positive check where the last value (on/off) is checked vs. the new value. Recommended when false-positives occur (ie. Domoticz meter value is higher than actual meter) is.</li>
+            <li>-Consistency check: Configure the false-positive check where consistency of the On/Off value is checked 300ms after the interrupt. Recommended when false-positives occur (ie. Domoticz meter value is higher than actual meter). </li>
+            <li>Debounce Time - Configure the cooldown time after the interrupt to prevent interrupt flooding. A high number is recommended, but it should be less then the time it takes to have 1 liter going throught your watermeter, to prevent lost measurements.</li> 
             <li>Meter Reading File - The path of the file where you want the actual meter reading to be stored. If you do not specifiy a path, the homefolder of this plugin will be used</li>
-            <li> Increment - The amount your domoticz counter must be incremented when a pulse of the watermeter is detected. In NL this is normally 1 liter. In belgium apparently this is 2 ticks per liter (value should then be 0.5).</li>
+            <li>Increment - The amount your domoticz counter must be incremented when a pulse of the watermeter is detected. In NL this is normally 1 liter. In belgium apparently this is 2 ticks per liter (value should then be 0.5).</li>
 
             <br/>
-            Last but not least: A normal (dutch) watermeter measures 1 liter every pulse on the gpio pin. The meter in domoticz is of the type m3. So in order to have this meter to show the correct amount, you have to change the RFX Meter/Counter Setup in domoticz. If this is not set correctly: <br />
+            Last but not least: A normal (Dutch) watermeter measures 1 liter every pulse on the GPIO pin. The meter in domoticz is of the type M3. So in order to have this meter to show the correct amount, you have to change the RFX Meter/Counter Setup in domoticz. If this is not set correctly: <br />
             - Go to domoticz web interface<br/>
             - Click on Setup<br/>
             - Click on Settings<br/>
             - Click on Meters/Counters<br/>
-            - Set the value of the water divider to 1000  (1m3 = 1000l ;-))<br/>
+            - Set the value of the water divider to 1000  (1 M3 = 1000 L ;-))<br/>
             - Click on Apply Settings  <br/><br/>
         </ul>
     </description>
     <params>
-         <param field="Mode1" label="GPIO Pin Number" width="70px">
+         <param field="Mode1" label="GPIO Pin Number" width="150px">
          <options>
             <option label="GPIO2" value="2" />
             <option label="GPIO3" value="3"/>
@@ -64,23 +67,32 @@
             <option label="GPIO24" value="24"/>
             <option label="GPIO25" value="25"/>
             <option label="GPIO26" value="26"/>
-        </options>
+         </options>
          </param> 
-         <param field="Mode2" label="Resistor Type" width="70px">
+         <param field="Mode2" label="Resistor Type" width="150px">
          <options>
             <option label="PullUp" value="PU" default="true"/>
             <option label="PullDown" value="PD"/>
             <option label="None" value="None"/>
-        </options>
+         </options>
          </param> 
-         <param field="Mode3" label="Interrupt mode" width="150px" required="true">
+         <param field="Mode3" label="Interrupt and check mode" width="150px" required="true">
          <options>
-            <option label="Falling" value="Falling" default="true"/>
-            <option label="Rising" value="Rising"/>
-            <option label="Both" value="Both"/>	
-        </options>
-        </param>
-         <param field="Mode4" label="debounce time (ms)" width="150px" required="true">
+            <option label="Falling / No checks" value="Falling" default="true"/>
+            <option label="Falling / Last value check" value="FallingLast"/>
+            <option label="Falling / Consistency check" value="FallingConsistency"/>
+            <option label="Falling / Last value check / Consistency check" value="FallingLastConsistency"/>
+            <option label="Rising  / No checks" value="Rising" default="true"/>
+            <option label="Rising  / Last value check" value="RisingLast"/>
+            <option label="Rising  / Consistency check" value="RisingConsistency"/>
+            <option label="Rising  / Last value check / Consistency check" value="RisingLastConsistency"/>
+            <option label="Both    / No checks" value="Both"/>	
+            <option label="Both    / Last value check" value="BothLast"/>	
+            <option label="Both    / Consistency check" value="BothConsistency"/>
+            <option label="Both    / Last value check / Consistency check" value="BothLastConsistency"/>	
+         </options>
+         </param>
+         <param field="Mode4" label="Debounce time (ms)" width="150px" required="true">
          <options>
             <option label="0" value="0" />
             <option label="50" value="50" />
@@ -102,15 +114,15 @@
          </options>
          </param>
          <param field="Mode5" label="Meter Reading File" width="150px" required="true" default="meterstand_water.txt" />
-         <param field="Mode6" label="Increment" width="70px" default="1"/>
+         <param field="Mode6" label="Increment" width="70px" default="1"/> 
      </params>
 </plugin>
 """
+
 import Domoticz
 import RPi.GPIO as GPIO
 import os
 import time
-
 
 #setup global vars
 #global debug
@@ -122,11 +134,13 @@ fakereading=False        # for testing purposes. Will generate a "tick" every 10
 debug=False #True/False             # set to true to enable debug logging
 #if os.path.exists(str(Parameters["HomeFolder"])+"DEBUG"): 
 
-last_value=0
-interrupt = GPIO.BOTH
+last_value        = 0
+interrupt         = GPIO.BOTH
+check_last_value  = 'OFF'
+check_consistency = 'OFF'
+
 
 class BasePlugin:
-
 
     enabled = False
     def __init__(self):
@@ -137,6 +151,9 @@ class BasePlugin:
         global fakereading
         global last_value
         global interrupt
+        global gpio_pin
+        global check_last_value
+        global check_consistency
 
         #Check if we have to switch on debug mode
         if os.path.exists(str(Parameters["HomeFolder"])+"DEBUG"): 
@@ -152,7 +169,9 @@ class BasePlugin:
         else:
             fakereading=False
 
+
         Debug("OnStart called")
+		
         if debug==True:
             Debug("In Debug mode: Dumping config to log...") 
             DumpConfigToLog()
@@ -170,19 +189,48 @@ class BasePlugin:
         else:
             Debug("No resistor configured")
 
-        if Parameters["Mode3"]=="Falling":
+        # By default false positive checks are switched OFF
+        check_last_value = "OFF"
+        check_consistency = "OFF"
+
+        # Get Interrupt and check mode config
+        if Parameters["Mode3"]=="Falling" or Parameters["Mode3"]=="FallingLast" or Parameters["Mode3"]=="FallingConsistency" or Parameters["Mode3"]=="FallingLastConsistency":
             interrupt=GPIO.FALLING
             Debug("Falling interrupt detected")
-        elif Parameters["Mode3"]=="Rising":
+            if Parameters["Mode3"]=="FallingLast":
+                check_last_value = "ON"
+            elif Parameters["Mode3"]=="FallingConsistency":
+                check_consistency = "ON"
+            elif Parameters["Mode3"]=="FallingLastConsistency":
+                check_last_value = "ON"
+                check_consistency = "ON"
+        elif Parameters["Mode3"]=="Rising" or Parameters["Mode3"]=="RisingLast" or Parameters["Mode3"]=="RisingConsistency" or Parameters["Mode3"]=="RisingLastConsistency":
             interrupt=GPIO.RISING
             Debug("Rising Interrupt detected")
-        else:
+            if Parameters["Mode3"]=="RisingLast":
+                check_last_value = "ON"
+            elif Parameters["Mode3"]=="RisingConsistency":
+                check_consistency = "ON"
+            elif Parameters["Mode3"]=="RisingLastConsistency":
+                check_last_value = "ON"
+                check_consistency = "ON"
+        elif Parameters["Mode3"]=="Both" or Parameters["Mode3"]=="BothLast" or Parameters["Mode3"]=="BothConsistency" or Parameters["Mode3"]=="BothLastConsistency":
             interrupt=GPIO.BOTH
             Debug("Both interrupt detected")
-        Debug("Interrupt Type="+str(interrupt))
+            if Parameters["Mode3"]=="BothLast":
+                check_last_value = "ON"
+            elif Parameters["Mode3"]=="BothConsistency":
+                check_consistency = "ON"
+            elif Parameters["Mode3"]=="BothLastConsistency":
+                check_last_value = "ON"
+                check_consistency = "ON"
+
+        Debug("Interrupt Type = "+str(interrupt))
+        Debug("Consistency check = "+str(check_consistency))
+        Debug("Last value check = "+str(check_last_value))
 
         bouncetime=int(Parameters["Mode4"])
-        Debug("Bouncetime="+str(bouncetime))
+        Debug("Bouncetime = "+str(bouncetime))
 
         fn=Parameters["Mode5"]
         increment=int(Parameters["Mode6"])
@@ -202,8 +250,7 @@ class BasePlugin:
         # Store initial value
         last_value=GPIO.input(gpio_pin)
 
-        # Set GPIO event detection with interrupt on both rising and falling for false positive detection
-        GPIO.add_event_detect(gpio_pin, GPIO.BOTH, callback = Interrupt, bouncetime = bouncetime)  
+        GPIO.add_event_detect(gpio_pin, GPIO.BOTH, callback = Interrupt, bouncetime = bouncetime)
 
         #Create device if needed
         if (len(Devices) == 0):
@@ -320,45 +367,56 @@ def WriteMeterFile(counter):
 
 def Interrupt(channel):
 
-    global last_value
     global interrupt
+    global gpio_pin
+    global check_last_value
+    global check_consistency
+    global last_value
 
     Debug("Start processing...")
-
-    # Get pin config from settings
-    gpio_pin=int(Parameters["Mode1"])
-
     Debug("Last value GPIO.input("+str(gpio_pin)+") = "+str(last_value))
+    
+    # Get current (new) GPIO value
     new_value = GPIO.input(gpio_pin)
     Debug("Detected value GPIO.input("+str(gpio_pin)+") = "+str(new_value))
-    # Sleep for 300 ms to check pin state for false positives and compare with previous known value
-    time.sleep(0.3)
-    #Debug("And awake..")
-    newest_value = GPIO.input(gpio_pin)
-    Debug("Newest value GPIO.input("+str(gpio_pin)+") = "+str(newest_value))
 
-    # Need to filter out the false positive of some power fluctuation
-    # 1. Compare new value with newest (deviation within 300ms seems like a power fluctuation)
-    if new_value != newest_value:
-        Debug("Interrupt detected, but not consistent; false positive -> exit")
-        Domoticz.Log("Interrupt detected; inconsistent; last '"+str(last_value)+"' -> new '"+str(new_value)+"' -> newest '"+str(newest_value)+"'; false positive -> exit")
-        return
-    # 2. Compare newest value with last known value (before trigger)    
-    elif newest_value == last_value:
-        Domoticz.Log("Interrupt detected, but same value; last '"+str(last_value)+"' -> new '"+str(new_value)+"' -> newest '"+str(newest_value)+"'; false positive -> exit")
-        return
-    # 3. We detect both falling and rising (otherwise we can't detect false positives in both ways); but setting for Interrupt mode should be adhered to
-    elif (newest_value == 1 and interrupt == GPIO.FALLING) or (newest_value == 0 and interrupt == GPIO.RISING):
+    # Consistency check logic
+    if check_consistency == "ON":
+        # Sleep for 300 ms to check pin state for false positives and compare with previous known value
+        time.sleep(0.3)
+        Debug("And awake..")
+		
+        # Get current (newest) GPIO value
+        newest_value = GPIO.input(gpio_pin)
+        Debug("Newest value GPIO.input("+str(gpio_pin)+") = "+str(newest_value))
+
+        # Compare new value with newest (deviation within 300ms seems like a power fluctuation)
+        if new_value != newest_value:
+            Debug("Interrupt detected, but not consistent; false positive -> exit")
+            Domoticz.Log("Interrupt detected, but not consistent; last '"+str(last_value)+"' -> new '"+str(new_value)+"' -> newest '"+str(newest_value)+"'; false positive -> exit")
+            return
+
+    # Last value check logic    
+    if check_last_value == "ON":
+        # Compare newest value with last known value (before trigger)
+        if new_value == last_value:
+            Debug("Interrupt detected, but same value; last '"+str(last_value)+"' -> new '"+str(new_value)+"; false positive -> exit")
+            Domoticz.Log("Interrupt detected, but same value; last '"+str(last_value)+"' -> new '"+str(new_value)+"; false positive -> exit")
+            return
+
+	# We detect both falling and rising (otherwise we cannot detect false positives in both ways); but setting for Interrupt mode should be adhered to
+    if (new_value == 1 and interrupt == GPIO.FALLING) or (new_value == 0 and interrupt == GPIO.RISING):
         Debug("Interrupt detected, but wrong type; last '"+str(last_value)+"' -> new '"+str(new_value)+"'; update 'last_value' with 'new_value' -> exit")
-        last_value = newest_value
+        last_value = new_value
         return
 
-    Debug("Interrupt detected, checks are OK; last '"+str(last_value)+"' -> new '"+str(new_value)+"' -> newest '"+str(newest_value)+"'; change 'last_value' into newest -> continue")
+    Debug("Interrupt detected, checks (if applicable) are OK;")
+    Debug("Last '"+str(last_value)+"' -> new '"+str(new_value)+"; change 'last_value' into new value")
 
     # Store current value as 'last_value' and continue 
-    last_value = newest_value
+    last_value = new_value
 
-    Debug("And we continue increasing the counter..")
+    Debug("Continue increasing the counter..")
     Debug("Processing Meter Pulse (1 liter water)")
 
     counter=GetMeterFile()


### PR DESCRIPTION
Voorkomen van false-positives door:
-Bij een 'trigger' vergelijken of deze aan/uit waarde 300ms later nog steeds hetzelfde is (dit is wat anders dan debounce time).
-De laatst bekende waarde (aan/uit) in een variabele last_value 'opslaan' om bij een volgende trigger te vergelijken (als vorige 'aan' was, wordt een daarop volgende 'aan' genegeerd en moet er eerst een 'uit' geregistreerd zijn)
-Altijd op zowel falling als rising reageren (dus both) om de laatst bekende waarde te updaten; vervolgens afhankelijk van de falling/rising setting de logica voor bijwerken meterstand uitvoeren of skippen.